### PR TITLE
feat(freshrss): remove OIDC Auth

### DIFF
--- a/apps/freshrss/Dockerfile
+++ b/apps/freshrss/Dockerfile
@@ -33,27 +33,19 @@ COPY ./entrypoint.sh /entrypoint.sh
 
 RUN apk update && \
     apk upgrade --no-cache && \
-    echo 'http://dl-cdn.alpinelinux.org/alpine/edge/testing' >> /etc/apk/repositories && \
-    apk update && \
-    apk add --no-cache apache-mod-auth-openidc && \
     mkdir -p /run/apache2 && \
     chown -R nobody:nogroup /var/www/FreshRSS /run/apache2 && \
     rm -f /var/www/FreshRSS/cli/access-permissions.sh /etc/crontab.freshrss.default && \
     sed -i -E "s#^\\#Listen 80#Listen \${LISTEN}#" /etc/apache2/httpd.conf && \
+    echo "LoadModule negotiation_module modules/mod_negotiation.so" >> /etc/apache2/httpd.conf && \
     find /etc/php*/ -type f -name php.ini -exec sed -i -E \
     -e "\\#^;?post_max_size#s#^.*#post_max_size = \${PHP_POST_MAX_SIZE}#" \
-    -e "\\#^;?upload_max_filesize#s#^.*#upload_max_filesize = \${PHP_MAX_FILESIZE}#" {} \; && \
-    rm -f /etc/apache2/conf.d/mod-auth-openidc.conf && \
-    cat <<EOF > /etc/apache2/conf.d/01-mod-auth-openidc.conf
-<IfDefine OIDC_ENABLED>
-LoadModule auth_openidc_module /usr/lib/apache2/mod_auth_openidc.so
-</IfDefine>
-EOF
+    -e "\\#^;?upload_max_filesize#s#^.*#upload_max_filesize = \${PHP_MAX_FILESIZE}#" {} \;
 
 USER nobody:nogroup
 
 ENTRYPOINT ["/entrypoint.sh"]
 
-CMD exec httpd -D FOREGROUND $([ -n "$OIDC_ENABLED" ] && [ "$OIDC_ENABLED" -ne 0 ] && echo '-D OIDC_ENABLED')
+CMD exec httpd -D FOREGROUND
 
 EXPOSE 8080

--- a/apps/freshrss/entrypoint.sh
+++ b/apps/freshrss/entrypoint.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 # This file is based on the upstream FreshRSS project (https://github.com/FreshRSS/FreshRSS)
 # Licensed under the AGPL-3.0 License.
 # Modifications have been made to adapt it for specific use cases.
@@ -6,20 +7,6 @@
 # Modifications Author: Benjamin Pinchon (mydoomfr)
 #
 # This file is distributed under the AGPL-3.0 License.
-#!/bin/sh
-
-if [ -n "$OIDC_ENABLED" ] && [ "$OIDC_ENABLED" -ne 0 ]; then
-	# Default values
-	export OIDC_SESSION_INACTIVITY_TIMEOUT="${OIDC_SESSION_INACTIVITY_TIMEOUT:-300}"
-	export OIDC_SESSION_MAX_DURATION="${OIDC_SESSION_MAX_DURATION:-27200}"
-	export OIDC_SESSION_TYPE="${OIDC_SESSION_TYPE:-server-cache}"
-
-	if [ -n "$OIDC_SCOPES" ]; then
-		# Compatibility with : as separator instead of space
-		OIDC_SCOPES=$(echo "$OIDC_SCOPES" | tr ':' ' ')
-		export OIDC_SCOPES
-	fi
-fi
 
 php -f ./cli/prepare.php >/dev/null
 

--- a/apps/freshrss/tests.yaml
+++ b/apps/freshrss/tests.yaml
@@ -1,12 +1,5 @@
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/goss-org/goss/master/docs/schema.yaml
-file:
-  /usr/lib/apache2/mod_auth_openidc.so:
-    exists: true
-  /etc/apache2/conf.d/01-mod-auth-openidc.conf:
-    exists: true
-  /etc/apache2/conf.d/mod-auth-openidc.conf:
-    exists: false
 port:
   tcp6:8080:
     listening: true


### PR DESCRIPTION
The `apache-mod-auth-openidc` package from Alpine's edge/testing repository requires `libhiredis.so.1.3.0` but only `libhiredis.so.1.2.0` is available in the current Alpine Linux package repositories, creating an unresolvable dependency conflict.